### PR TITLE
Consumer tag assignment fix; timeout consistency

### DIFF
--- a/src/Channel.php
+++ b/src/Channel.php
@@ -224,7 +224,9 @@ final class Channel
                 /** @var Protocol\BasicConsumeOkFrame $result */
                 $result = yield $this->await(Protocol\BasicConsumeOkFrame::class);
 
-                $consumerTag = $result->consumerTag;
+                if('' === $consumerTag) {
+                    $consumerTag = $result->consumerTag;
+                }
             }
 
             $this->startConsuming();

--- a/src/Client.php
+++ b/src/Client.php
@@ -83,8 +83,10 @@ final class Client
 
             $this->connection = new Connection($this->config->uri());
 
+            $timeout = $this->config->timeout() * 1000;
+
             yield $this->connection->open(
-                $this->config->timeout(),
+                $timeout,
                 $this->config->tcpAttempts(),
                 $this->config->tcpNoDelay()
             );

--- a/src/Config.php
+++ b/src/Config.php
@@ -218,7 +218,7 @@ final class Config
      */
     public function timeout(int $value = null): int
     {
-        return \is_null($value) || 0 === $value ? $this->timeout : $this->timeout = $value;
+        return \is_null($value) ? $this->timeout : $this->timeout = $value;
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -218,7 +218,7 @@ final class Config
      */
     public function timeout(int $value = null): int
     {
-        return \is_null($value) ? $this->timeout : $this->timeout = $value;
+        return \is_null($value) || 0 === $value ? $this->timeout : $this->timeout = $value;
     }
 
     /**

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -197,7 +197,7 @@ final class Connection
         $milliseconds = $interval * 1000;
 
         $this->heartbeat = Loop::repeat($milliseconds, function($watcher) use ($milliseconds) {
-            if (!$this->socket) {
+            if (false === isset($this->socket)) {
                 Loop::cancel($watcher);
 
                 return;

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -88,7 +88,7 @@ final class Connection
             // payload already supplied
         } elseif ($frame instanceof MethodFrame || $frame instanceof ContentHeaderFrame) {
             $buffer = $frame->pack();
-        
+
             $frame->size    = $buffer->size();
             $frame->payload = $buffer;
         } elseif ($frame instanceof Protocol\ContentBodyFrame) {
@@ -156,10 +156,11 @@ final class Connection
     public function open(int $timeout, int $maxAttempts, bool $noDelay): Promise
     {
         return call(function () use ($timeout, $maxAttempts, $noDelay) {
-            $context = (new ClientConnectContext)
-                ->withConnectTimeout($timeout)
-                ->withMaxAttempts($maxAttempts)
-            ;
+            $context = (new ClientConnectContext)->withMaxAttempts($maxAttempts);
+
+            if($timeout > 0) {
+                $context = $context->withConnectTimeout($timeout);
+            }
 
             if ($noDelay) {
                 $context->withTcpNoDelay();

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -183,7 +183,7 @@ final class Connection
                     }
                 }
 
-                unset($this->socket);
+                $this->socket = null;
             });
         });
     }
@@ -198,7 +198,7 @@ final class Connection
         $milliseconds = $interval * 1000;
 
         $this->heartbeat = Loop::repeat($milliseconds, function($watcher) use ($milliseconds) {
-            if (false === isset($this->socket)) {
+            if (null === $this->socket) {
                 Loop::cancel($watcher);
 
                 return;


### PR DESCRIPTION
* Fixed bug with assigning a consumer tags when adding multiple listeners
* Working with seconds in timeout configuration
* ```Notice: Undefined property: PHPinnacle\Ridge\Connection::$socket``` fixed https://github.com/phpinnacle/ridge/issues/6